### PR TITLE
max 包含 lal 统计接口与通知

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -8,14 +8,16 @@ import (
 var defaultConfig Config
 
 type Config struct {
-	SrtConfig        SrtConfig      `json:"srt_config"`      // srt配置
-	RtcConfig        RtcConfig      `json:"rtc_config"`      // rtc配置
-	HttpConfig       HttpConfig     `json:"http_config"`     // http/https配置
-	HttpFmp4Config   HttpFmp4Config `json:"httpfmp4_config"` // http-fmp4配置
-	HlsConfig        HlsConfig      `json:"hls_config"`      // hls-fmp4/llhls配置
-	GB28181Config    GB28181Config  `json:"gb28181_config"`  // gb28181配置
-	OnvifConfig      OnvifConfig    `json:"onvif_config"`    //
-	LalSvrConfigPath string         `json:"lal_config_path"` // lal配置目录
+	SrtConfig        SrtConfig        `json:"srt_config"`      // srt配置
+	RtcConfig        RtcConfig        `json:"rtc_config"`      // rtc配置
+	HttpConfig       HttpConfig       `json:"http_config"`     // http/https配置
+	HttpFmp4Config   HttpFmp4Config   `json:"httpfmp4_config"` // http-fmp4配置
+	HlsConfig        HlsConfig        `json:"hls_config"`      // hls-fmp4/llhls配置
+	GB28181Config    GB28181Config    `json:"gb28181_config"`  // gb28181配置
+	OnvifConfig      OnvifConfig      `json:"onvif_config"`    //
+	ServerId         string           `json:"server_id"`       // http 通知唯一标识
+	HttpNotifyConfig HttpNotifyConfig `json:"http_notify"`     // http 通知配置
+	LalSvrConfigPath string           `json:"lal_config_path"` // lal配置目录
 }
 
 type SrtConfig struct {
@@ -73,6 +75,21 @@ type GB28181MediaConfig struct {
 
 type OnvifConfig struct {
 	Enable bool `json:"enable"`
+}
+
+type HttpNotifyConfig struct {
+	Enable            bool   `json:"enable"`
+	UpdateIntervalSec int    `json:"update_interval_sec"`
+	OnServerStart     string `json:"on_server_start"`
+	OnUpdate          string `json:"on_update"`
+	OnPubStart        string `json:"on_pub_start"`
+	OnPubStop         string `json:"on_pub_stop"`
+	OnSubStart        string `json:"on_sub_start"`
+	OnSubStop         string `json:"on_sub_stop"`
+	OnRelayPullStart  string `json:"on_relay_pull_start"`
+	OnRelayPullStop   string `json:"on_relay_pull_stop"`
+	OnRtmpConnect     string `json:"on_rtmp_connect"`
+	OnHlsMakeTs       string `json:"on_hls_make_ts"`
 }
 
 func Open(filepath string) error {

--- a/conf/lalmax.conf.json
+++ b/conf/lalmax.conf.json
@@ -1,43 +1,57 @@
 {
-    "srt_config": {
-      "enable": true,
-      "addr": ":6001"
+  "srt_config": {
+    "enable": true,
+    "addr": ":6001"
+  },
+  "rtc_config": {
+    "enable": true,
+    "iceHostNatToIps": [],
+    "iceUdpMuxPort": 4888,
+    "iceTcpMuxPort": 4888
+  },
+  "http_config": {
+    "http_listen_addr": ":1290",
+    "enable_https": true,
+    "https_listen_addr": ":1233",
+    "https_cert_file": "./conf/cert.pem",
+    "https_key_file": "./conf/key.pem"
+  },
+  "httpfmp4_config": {
+    "enable": true
+  },
+  "hls_config": {
+    "enable": true
+  },
+  "gb28181_config": {
+    "enable": true,
+    "serial": "34020000002000000001",
+    "realm": "3402000000",
+    "sipIp": "192.168.254.165",
+    "sipPort": 5060,
+    "sipNetwork": "udp",
+    "username": "",
+    "media_config": {
+      "mediaIp": "192.168.254.165"
     },
-    "rtc_config": {
-      "enable": true,
-      "iceHostNatToIps": [],
-      "iceUdpMuxPort": 4888,
-      "iceTcpMuxPort": 4888
-    },
-    "http_config": {
-      "http_listen_addr": ":1290",
-      "enable_https": true,
-      "https_listen_addr": ":1233",
-      "https_cert_file": "./conf/cert.pem",
-      "https_key_file": "./conf/key.pem"
-    },
-    "httpfmp4_config": {
-      "enable": true
-    },
-    "hls_config":{
-      "enable": true
-    },
-    "gb28181_config":{
-      "enable": true,
-      "serial": "34020000002000000001",
-      "realm": "3402000000",
-      "sipIp": "192.168.254.165",
-      "sipPort": 5060,
-      "sipNetwork": "udp",
-      "username": "",
-      "media_config": {
-        "mediaIp": "192.168.254.165"
-      },
-	  "quickLogin": true
-    },
-    "onvif_config": {
-      "enable": true
-    },
-    "lal_config_path:":"./conf/lalserver.conf.json"
+    "quickLogin": true
+  },
+  "onvif_config": {
+    "enable": true
+  },
+  "server_id": "1",
+  "http_notify": {
+    "enable": false,
+    "update_interval_sec": 5,
+    "on_update": "http://127.0.0.1:10101/on_update",
+    "on_pub_start": "http://127.0.0.1:10101/on_pub_start",
+    "on_pub_stop": "http://127.0.0.1:10101/on_pub_stop",
+    "on_sub_start": "http://127.0.0.1:10101/on_sub_start",
+    "on_sub_stop": "http://127.0.0.1:10101/on_sub_stop",
+    "on_relay_pull_start": "http://127.0.0.1:10101/on_relay_pull_start",
+    "on_relay_pull_stop": "http://127.0.0.1:10101/on_relay_pull_stop",
+    "on_rtmp_connect": "http://127.0.0.1:10101/on_rtmp_connect",
+    "on_server_start": "http://127.0.0.1:10101/on_server_start",
+    "on_hls_make_ts": "http://127.0.0.1:10101/on_hls_make_ts"
+  },
+  "lal_config_path:": "./conf/lalserver.conf.json"
 }
-

--- a/server/http_notify.go
+++ b/server/http_notify.go
@@ -1,0 +1,216 @@
+// Copyright 2020, Chef.  All rights reserved.
+// https://github.com/q191201771/lal
+//
+// Use of this source code is governed by a MIT-style license
+// that can be found in the License file.
+//
+// Author: Chef (191201771@qq.com)
+
+package server
+
+import (
+	config "lalmax/conf"
+	"lalmax/hook"
+	"net/http"
+	"time"
+
+	"github.com/q191201771/lal/pkg/base"
+	"github.com/q191201771/naza/pkg/nazahttp"
+	"github.com/q191201771/naza/pkg/nazalog"
+)
+
+// TODO(chef): refactor 配置参数供外部传入
+// TODO(chef): refactor maxTaskLen修改为能表示是阻塞任务的意思
+var (
+	maxTaskLen       = 1024
+	notifyTimeoutSec = 3
+)
+
+var Log = nazalog.GetGlobalLogger()
+
+type PostTask struct {
+	url  string
+	info interface{}
+}
+
+type HttpNotify struct {
+	cfg config.HttpNotifyConfig
+
+	serverId string
+
+	taskQueue         chan PostTask
+	notifyUpdateQueue chan PostTask
+	client            *http.Client
+}
+
+func NewHttpNotify(cfg config.HttpNotifyConfig, serverId string) *HttpNotify {
+	httpNotify := &HttpNotify{
+		cfg:               cfg,
+		serverId:          serverId,
+		taskQueue:         make(chan PostTask, maxTaskLen),
+		notifyUpdateQueue: make(chan PostTask, maxTaskLen),
+		client: &http.Client{
+			Timeout: time.Duration(notifyTimeoutSec) * time.Second,
+		},
+	}
+	go httpNotify.RunLoop()
+	go httpNotify.NotifyUpdateRunLoop()
+
+	return httpNotify
+}
+
+// TODO(chef): Dispose
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+func (h *HttpNotify) NotifyServerStart(info base.LalInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnServerStart, info)
+}
+
+func (h *HttpNotify) NotifyUpdate(info base.UpdateInfo) {
+	info.ServerId = h.serverId
+	for i, v := range info.Groups {
+		exist, session := hook.GetHookSessionManagerInstance().GetHookSession(v.StreamName)
+		if exist {
+			info.Groups[i].StatSubs = append(info.Groups[i].StatSubs, session.GetAllConsumer()...)
+		}
+	}
+	h.notifyUpdateAsyncPost(h.cfg.OnUpdate, info)
+}
+
+func (h *HttpNotify) NotifyPubStart(info base.PubStartInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnPubStart, info)
+}
+
+func (h *HttpNotify) NotifyPubStop(info base.PubStopInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnPubStop, info)
+}
+
+func (h *HttpNotify) NotifySubStart(info base.SubStartInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnSubStart, info)
+}
+
+func (h *HttpNotify) NotifySubStop(info base.SubStopInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnSubStop, info)
+}
+
+func (h *HttpNotify) NotifyPullStart(info base.PullStartInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnRelayPullStart, info)
+}
+
+func (h *HttpNotify) NotifyPullStop(info base.PullStopInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnRelayPullStop, info)
+}
+
+func (h *HttpNotify) NotifyRtmpConnect(info base.RtmpConnectInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnRtmpConnect, info)
+}
+
+func (h *HttpNotify) NotifyOnHlsMakeTs(info base.HlsMakeTsInfo) {
+	info.ServerId = h.serverId
+	h.asyncPost(h.cfg.OnHlsMakeTs, info)
+}
+
+// ----- implement INotifyHandler interface ----------------------------------------------------------------------------
+
+func (h *HttpNotify) OnServerStart(info base.LalInfo) {
+	h.NotifyServerStart(info)
+}
+
+func (h *HttpNotify) OnUpdate(info base.UpdateInfo) {
+	h.NotifyUpdate(info)
+}
+
+func (h *HttpNotify) OnPubStart(info base.PubStartInfo) {
+	h.NotifyPubStart(info)
+}
+
+func (h *HttpNotify) OnPubStop(info base.PubStopInfo) {
+	h.NotifyPubStop(info)
+}
+
+func (h *HttpNotify) OnSubStart(info base.SubStartInfo) {
+	h.NotifySubStart(info)
+}
+
+func (h *HttpNotify) OnSubStop(info base.SubStopInfo) {
+	h.NotifySubStop(info)
+}
+
+func (h *HttpNotify) OnRelayPullStart(info base.PullStartInfo) {
+	h.NotifyPullStart(info)
+}
+
+func (h *HttpNotify) OnRelayPullStop(info base.PullStopInfo) {
+	h.NotifyPullStop(info)
+}
+
+func (h *HttpNotify) OnRtmpConnect(info base.RtmpConnectInfo) {
+	h.NotifyRtmpConnect(info)
+}
+
+func (h *HttpNotify) OnHlsMakeTs(info base.HlsMakeTsInfo) {
+	h.NotifyOnHlsMakeTs(info)
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+func (h *HttpNotify) RunLoop() {
+	for {
+		select {
+		case t := <-h.taskQueue:
+			h.post(t.url, t.info)
+		}
+	}
+}
+
+func (h *HttpNotify) NotifyUpdateRunLoop() {
+	for {
+		select {
+		case t := <-h.notifyUpdateQueue:
+			h.post(t.url, t.info)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+func (h *HttpNotify) notifyUpdateAsyncPost(url string, info interface{}) {
+	if !h.cfg.Enable || url == "" {
+		return
+	}
+
+	select {
+	case h.notifyUpdateQueue <- PostTask{url: url, info: info}:
+		// noop
+	default:
+		Log.Error("http notify queue full.")
+	}
+}
+
+func (h *HttpNotify) asyncPost(url string, info interface{}) {
+	if !h.cfg.Enable || url == "" {
+		return
+	}
+
+	select {
+	case h.taskQueue <- PostTask{url: url, info: info}:
+		// noop
+	default:
+		Log.Error("http notify queue full.")
+	}
+}
+
+func (h *HttpNotify) post(url string, info interface{}) {
+	if _, err := nazahttp.PostJson(url, info, h.client); err != nil {
+		Log.Errorf("http notify post error. err=%+v, url=%s, info=%+v", err, url, info)
+	}
+}

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	config "lalmax/conf"
+	"lalmax/hook"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/q191201771/lal/pkg/base"
+)
+
+var max *LalMaxServer
+
+const httpNotifyAddr = ":55559"
+
+func TestMain(m *testing.M) {
+	var err error
+	max, err = NewLalMaxServer(&config.Config{
+		HttpFmp4Config:   config.HttpFmp4Config{Enable: true},
+		LalSvrConfigPath: "../conf/lalserver.conf.json",
+		HttpConfig: config.HttpConfig{
+			ListenAddr: ":52349",
+		},
+		HttpNotifyConfig: config.HttpNotifyConfig{
+			Enable:            true,
+			UpdateIntervalSec: 2,
+			OnUpdate:          fmt.Sprintf("http://127.0.0.1%s/on_update", httpNotifyAddr),
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+	go max.Run()
+	os.Exit(m.Run())
+}
+
+func TestAllGroup(t *testing.T) {
+	_, err := max.lalsvr.AddCustomizePubSession("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("no consumer", func(t *testing.T) {
+		r := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/stat/all_group", nil)
+		max.router.ServeHTTP(r, req)
+		resp := r.Result()
+		if resp.StatusCode != 200 {
+			t.Fatal(resp.Status)
+		}
+		var out base.ApiStatAllGroupResp
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Data.Groups) <= 0 {
+			t.Fatal("no group")
+		}
+		if len(out.Data.Groups[0].StatSubs) != 0 {
+			t.Fatal("subs err")
+		}
+	})
+
+	t.Run("has consumer", func(t *testing.T) {
+		ss := hook.NewHookSession("test", "test", max.hlssvr)
+		ss.AddConsumer("consumer1", nil)
+		hook.GetHookSessionManagerInstance().SetHookSession("test", ss)
+
+		r := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/stat/all_group", nil)
+		max.router.ServeHTTP(r, req)
+		resp := r.Result()
+		if resp.StatusCode != 200 {
+			t.Fatal(resp.Status)
+		}
+		var out base.ApiStatAllGroupResp
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Data.Groups) <= 0 {
+			t.Fatal("no group")
+		}
+		if len(out.Data.Groups[0].StatSubs) <= 0 {
+			t.Fatal("subs err")
+		}
+		group := out.Data.Groups[0]
+		if group.StatSubs[0].SessionId != "consumer1" {
+			t.Fatal("SessionId err")
+		}
+	})
+}
+
+func TestNotifyUpdate(t *testing.T) {
+	_, err := max.lalsvr.AddCustomizePubSession("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := hook.NewHookSession("test", "test", max.hlssvr)
+	ss.AddConsumer("consumer1", nil)
+	hook.GetHookSessionManagerInstance().SetHookSession("test", ss)
+
+	http.HandleFunc("/on_update", func(w http.ResponseWriter, r *http.Request) {
+		var out base.ApiStatAllGroupResp
+		if err := json.NewDecoder(r.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Data.Groups) <= 0 {
+			t.Fatal("no group")
+		}
+		if len(out.Data.Groups[0].StatSubs) <= 0 {
+			t.Fatal("subs err")
+		}
+		group := out.Data.Groups[0]
+		if group.StatSubs[0].SessionId != "consumer1" {
+			t.Fatal("SessionId err")
+		}
+	})
+	go http.ListenAndServe(httpNotifyAddr, nil)
+	time.Sleep(time.Second * 3)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ type LalMaxServer struct {
 func NewLalMaxServer(conf *config.Config) (*LalMaxServer, error) {
 	lalsvr := logic.NewLalServer(func(option *logic.Option) {
 		option.ConfFilename = conf.LalSvrConfigPath
+		option.NotifyHandler = NewHttpNotify(conf.HttpNotifyConfig, conf.ServerId)
 	})
 
 	maxsvr := &LalMaxServer{


### PR DESCRIPTION
解决 #57 

1. 在 max 重写 lal 的三个状态接口，此接口更完整，将统计到存在 hook 的订阅者。
订阅者的详细数据还不够完善，这块涉及到多个函数签名的改动，放下一次处理。( 比如读了多少字节，远程地址，订阅协议类型等等 )。

2. 同时主动通知 notify update 时，也增加这些订阅者信息。 max 层的 http 通知可以覆盖 lal 层的，同时也将 lal 中的通知配置上移到 max 层。

3. 增加 router_test 来测试以上优化功能。