### PR TITLE
增加指定路由前缀鉴权

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -33,11 +33,13 @@ type RtcConfig struct {
 }
 
 type HttpConfig struct {
-	ListenAddr      string `json:"http_listen_addr"`  // http服务监听地址
-	EnableHttps     bool   `json:"enable_https"`      // https使能标志
-	HttpsListenAddr string `json:"https_listen_addr"` // https监听地址
-	HttpsCertFile   string `json:"https_cert_file"`   // https cert 文件
-	HttpsKeyFile    string `json:"https_key_file"`    // https key 文件
+	ListenAddr      string   `json:"http_listen_addr"`  // http服务监听地址
+	EnableHttps     bool     `json:"enable_https"`      // https使能标志
+	HttpsListenAddr string   `json:"https_listen_addr"` // https监听地址
+	HttpsCertFile   string   `json:"https_cert_file"`   // https cert 文件
+	HttpsKeyFile    string   `json:"https_key_file"`    // https key 文件
+	Authentication  string   `json:"authentication"`    // 认证信息，零值时不生效
+	AcceptIDs       []string `json:"accept_ids"`        // 允许访问的远程 IP，零值时不生效
 }
 
 type HttpFmp4Config struct {

--- a/conf/lalmax.conf.json
+++ b/conf/lalmax.conf.json
@@ -14,7 +14,9 @@
     "enable_https": true,
     "https_listen_addr": ":1233",
     "https_cert_file": "./conf/cert.pem",
-    "https_key_file": "./conf/key.pem"
+    "https_key_file": "./conf/key.pem",
+    "authentication": "",
+    "accept_ids": []
   },
   "httpfmp4_config": {
     "enable": true

--- a/document/config.md
+++ b/document/config.md
@@ -70,6 +70,20 @@
 
 *值举例*: "./conf/key.pem"
 
+- authentication: 鉴权的秘钥，用于访问以 `/api/stat` 和 `/api/ctrl` 前缀的接口，空串表示不鉴权，无权限访问时 http status 将会响应 200，其 error_code 为 401，用户请求鉴权的方式是增加 query 参数 `token`，例如 `token=secret`
+
+*类型*: string
+
+*值举例*: "7E3F6994-F073-4EE1-9F93-29BF42D5971D"
+
+- accept_ids: 远程 IP 白名单，用于访问以 `/api/stat` 和 `/api/ctrl` 前缀的接口，空数组表示允许任意 IP 访问，无权限访问时 http status 将会响应 200，其 error_code 为 401。注意，两种鉴权方式都不是零值时，必须同时满足才会通过鉴权。
+
+*类型*: []string
+
+*值举例*: ["192.168.1.2","192.168.1.3"]
+
+
+
 # http-fmp4配置
 主要用于设置http-fmp4相关的配置,需要配合http_config一起使用
 - enable: http-fmp4服务使能配置
@@ -125,43 +139,43 @@
 *值举例*: "0.0.0.0"
 
 - sipNetwork: 传输协议
-  
+
 *类型*: string
 
 *值举例*: "udp"
 
 - sipIp: sip服务器公网IP
-  
+
 *类型*: string
 
 *值举例*: "100.100.100.101"
 
 - sipPort: sip服务器公网端口
-  
+
 *类型*: uint16
 
 *值举例*: 5060
 
 - serial: sip服务器ID
-  
+
 *类型*: string
 
 *值举例*: "34020000002000000001"
 
 - realm: sip服务器域
-  
+
 *类型*: string
 
 *值举例*: "3402000000"
 
 - username: sip服务器账号
-  
+
 *类型*: string
 
 *值举例*: "admin"
 
 - password: sip服务器密码
-  
+
 *类型*: string
 
 *值举例*: "admin123"

--- a/server/middle.go
+++ b/server/middle.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/q191201771/lal/pkg/base"
+)
+
+func (s *LalMaxServer) Cors() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		method := c.Request.Method
+		c.Header("Access-Control-Allow-Origin", "*")
+		//服务器支持的所有跨域请求的方法
+		c.Header("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE,UPDATE")
+		//允许跨域设置可以返回其他子段，可以自定义字段
+		c.Header("Access-Control-Allow-Headers", "*")
+		// 允许浏览器（客户端）可以解析的头部 （重要）
+		c.Header("Access-Control-Expose-Headers", "Content-Length, Access-Control-Allow-Origin, Access-Control-Allow-Headers")
+		//设置缓存时间
+		c.Header("Access-Control-Max-Age", "172800")
+		//允许客户端传递校验信息比如 cookie (重要)
+		c.Header("Access-Control-Allow-Credentials", "true")
+
+		//允许类型校验
+		if method == "OPTIONS" {
+			c.Status(http.StatusOK)
+		}
+		c.Next()
+	}
+}
+
+// Authentication 接口鉴权
+func Authentication(token string, acceptIPs []string) gin.HandlerFunc {
+	out := base.ApiRespBasic{
+		ErrorCode: http.StatusUnauthorized,
+		Desp:      http.StatusText(http.StatusUnauthorized),
+	}
+	return func(c *gin.Context) {
+		if !authentication(c.Query("token"), token, c.ClientIP(), acceptIPs) {
+			c.JSON(200, out)
+			return
+		}
+		c.Next()
+	}
+}
+
+// authentication 判断是否符合要求，返回 false 表示鉴权失败
+func authentication(reqToken, svcToken, clientIP string, acceptIPs []string) bool {
+	// token 鉴权失败
+	if svcToken != "" && reqToken != svcToken {
+		return false
+	}
+	// ip 白名单过滤
+	if len(acceptIPs) > 0 && !containFn(acceptIPs, clientIP) {
+		return false
+	}
+	return true
+}
+
+func containFn[T comparable](ts []T, t T) bool {
+	for _, v := range ts {
+		if v == t {
+			return true
+		}
+	}
+	return false
+}

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -121,3 +121,36 @@ func TestNotifyUpdate(t *testing.T) {
 	go http.ListenAndServe(httpNotifyAddr, nil)
 	time.Sleep(time.Second * 3)
 }
+
+func TestAuthentication(t *testing.T) {
+	t.Run("无须鉴权", func(t *testing.T) {
+		if !authentication("12", "", "192.168.0.2", nil) {
+			t.Fatal("期望通过， 但实际未通过")
+		}
+	})
+	t.Run("Token 鉴权失败", func(t *testing.T) {
+		if authentication("1", "12", "192.168.0.2", nil) {
+			t.Fatal("期望不通过， 但实际通过")
+		}
+	})
+	t.Run("token 鉴权成功", func(t *testing.T) {
+		if !authentication("12", "12", "192.168.0.2", nil) {
+			t.Fatal("期望通过， 但实际不通过")
+		}
+	})
+	t.Run("ip 白名单鉴权失败", func(t *testing.T) {
+		if authentication("12", "", "192.168.0.2", []string{"192.168.1.2"}) {
+			t.Fatal("期望不通过， 但实际通过")
+		}
+	})
+	t.Run("ip 白名单鉴权成功", func(t *testing.T) {
+		if !authentication("12", "12", "192.168.0.2", []string{"192.168.0.2"}) {
+			t.Fatal("期望通过， 但实际不通过")
+		}
+	})
+	t.Run("两种模式结合鉴权通过", func(t *testing.T) {
+		if !authentication("12", "12", "192.168.0.2", []string{"192.168.0.2"}) {
+			t.Fatal("期望通过， 但实际不通过")
+		}
+	})
+}


### PR DESCRIPTION
支持 #69

1. 增加秘钥鉴权，双方协商字符串相等，即鉴权通过。参数通过 query 传递，如 "token=srcret"。
2. 增加 ip 白名单鉴权，请求客户端必须是 ip 白名单内才允许访问。
3. 配置文件增加 authentication 和 accept_ips 配置，默认空串空数组，表示不鉴权。
4. 两者可以分别单独开启，也可以同时开启。
5.  doc/config.md 增加文档说明。
6. 增加测试函数 TestAuthentication