### PR TITLE
rtc 发送 header

### DIFF
--- a/rtc/jessibucasession.go
+++ b/rtc/jessibucasession.go
@@ -1,6 +1,9 @@
 package rtc
 
 import (
+	"lalmax/hook"
+	"math"
+
 	"github.com/gofrs/uuid"
 	"github.com/pion/webrtc/v3"
 	"github.com/q191201771/lal/pkg/base"
@@ -8,8 +11,6 @@ import (
 	"github.com/q191201771/lal/pkg/logic"
 	"github.com/q191201771/lal/pkg/remux"
 	"github.com/q191201771/naza/pkg/nazalog"
-	"lalmax/hook"
-	"math"
 )
 
 type jessibucaSession struct {
@@ -82,7 +83,7 @@ func (conn *jessibucaSession) GetAnswerSDP(offer string) (sdp string) {
 }
 
 func (conn *jessibucaSession) Run() {
-	ok, session := hook.GetHookSessionManagerInstance().GetHookSession(conn.streamId)
+	ok, _ := hook.GetHookSessionManagerInstance().GetHookSession(conn.streamId)
 	if ok {
 		conn.hooks.AddConsumer(conn.subscriberId, conn)
 
@@ -106,27 +107,6 @@ func (conn *jessibucaSession) Run() {
 					return
 				}
 
-				videoHeader := session.GetVideoSeqHeaderMsg()
-				audioHeader := session.GetAudioSeqHeaderMsg()
-
-				if videoHeader != nil {
-					lazyRtmpMsg2FlvTag := remux.LazyRtmpMsg2FlvTag{}
-					videoHeader.Header.TimestampAbs = 0
-					lazyRtmpMsg2FlvTag.Init(*videoHeader)
-					if err := conn.DC.Send(lazyRtmpMsg2FlvTag.GetEnsureWithoutSdf()); err != nil {
-						nazalog.Warnf(" stream write videoHeader err:%s", err.Error())
-						return
-					}
-				}
-				if audioHeader != nil {
-					lazyRtmpMsg2FlvTag := remux.LazyRtmpMsg2FlvTag{}
-					audioHeader.Header.TimestampAbs = 0
-					lazyRtmpMsg2FlvTag.Init(*audioHeader)
-					if err := conn.DC.Send(lazyRtmpMsg2FlvTag.GetEnsureWithoutSdf()); err != nil {
-						nazalog.Warnf("stream write audioHeader err:%s", err.Error())
-						return
-					}
-				}
 				defer func() {
 					conn.DC.Close()
 					conn.pc.Close()
@@ -184,9 +164,6 @@ func (conn *jessibucaSession) OnMsg(msg base.RtmpMsg) {
 			conn.msgChan <- msg
 		}
 	case base.RtmpTypeIdVideo:
-		if msg.IsVideoKeySeqHeader() {
-			return
-		}
 		if conn.DC != nil {
 			conn.msgChan <- msg
 		}


### PR DESCRIPTION
遇到场景，客户端连接上了，服务端还没分析到 header 的情况。

因为 onMsg 里面控制了不发送 header ，这样就导致客户端一直收不到 header ，播放不出来。

因此解决此问题。

1. 在 jessibucasession.go 里面删除发送 header 代码
2. 在 onMsg 不限制发送 header